### PR TITLE
update dependencies

### DIFF
--- a/org.horizon_eda.HorizonEDA.json
+++ b/org.horizon_eda.HorizonEDA.json
@@ -39,8 +39,8 @@
            "sources": [
                {
                    "type": "archive",
-                   "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.2.tar.xz",
-                   "sha256": "a2a99f3fa943cf662f189163ed39a2cfc19a428d906dd4f92b387d3659d1641d"
+                   "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.3.tar.xz",
+                   "sha256": "e81596625899aacf1d0bf27ccc2fcc7f373405ec48735ca1c7273c0fbcdc1ef5"
                }
            ]
         },
@@ -50,8 +50,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.6.tar.xz",
-                    "sha256": "dda176dc4681bda9d5a2ac1bc55273bdd381662b7a6d49e918267d13e8774e1b"
+                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.7.tar.xz",
+                    "sha256": "d082a2ce72c750f66b1a415abe3e852df2eae1e8af53010f4ac2ea261a478832"
                 }
             ]
         },
@@ -62,8 +62,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.0.tar.xz",
-                    "sha256": "9e1db7d43d2e2d4dfa2771354e21a69a6beec7c446b711619cf8c779e13a581e"
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.1.tar.xz",
+                    "sha256": "69bd6b5327716ca2f511ab580a969fd7bf0cd2c24ce15e1d0e530592d3ff209c"
                 }
             ]
         },
@@ -73,8 +73,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
-                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
+                    "url": "https://www.cairographics.org/releases/cairomm-1.14.3.tar.xz",
+                    "sha256": "0d37e067c5c4ca7808b7ceddabfe1932c5bd2a750ad64fb321e1213536297e78"
                 }
             ]
         },
@@ -85,8 +85,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.0.tar.xz",
-                    "sha256": "d3787d04d6198b606f3efa357b3b452a7140e2a7dee56f9f9ce516d7d5fcec1b"
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.1.tar.xz",
+                    "sha256": "c885013fe61a4c5117fda395770d507563411c63e49f4a3aced4c9efe34d9975"
                 }
             ]
         },
@@ -97,8 +97,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.1.tar.xz",
-                    "sha256": "116876604770641a450e39c1f50302884848ce9cc48d43c5dc8e8efc31f31bad"
+                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.2.tar.xz",
+                    "sha256": "a0bb49765ceccc293ab2c6735ba100431807d384ffa14c2ebd30e07993fd2fa4"
                 }
             ]
         },
@@ -109,8 +109,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.4.tar.xz",
-                    "sha256": "9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743"
+                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.5.tar.xz",
+                    "sha256": "856333de86689f6a81c123f2db15d85db9addc438bc3574c36f15736aeae22e6"
                 }
             ]
         },
@@ -146,8 +146,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libgit2/libgit2/archive/v1.1.0.tar.gz",
-                    "sha256": "41a6d5d740fd608674c7db8685685f45535323e73e784062cf000a633d420d1e"
+                    "url": "https://github.com/libgit2/libgit2/archive/v1.1.1.tar.gz",
+                    "sha256": "13a525373f64c711a00a058514d890d1512080265f98e0935ab279393f21a620"
                 }
             ]
         },
@@ -171,8 +171,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2",
-                    "sha256": "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2",
+                    "sha256": "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
                 }
             ],
             "buildsystem": "simple",

--- a/org.horizon_eda.HorizonEDA.json
+++ b/org.horizon_eda.HorizonEDA.json
@@ -267,8 +267,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/horizon-eda/horizon/archive/refs/tags/v2.0.0.tar.gz",
-                    "sha256": "978fab9a20d367abfb785ef592e61648d0b21c8e573a7556325035e23f0110c3"
+                    "url": "https://github.com/horizon-eda/horizon/archive/refs/tags/v2.0.90.tar.gz",
+                    "sha256": "70e2b04e87172f2ff930e2f2a91291d55e90a82cc2c65f3f9a7c2eeb78c51637"
                 }
             ]
         }


### PR DESCRIPTION
mm-common : 1.0.2  -> 1.0.3
libsigc++ : 2.10.6 -> 2.10.7
glibmm    : 2.66.0 -> 2.661
cairomm   : 1.12.0 -> 1.14.3
pangomm   : 2.46.0 -> 2.46.1
atkmm     : 2.28.1 -> 2.28.2
gtkmm     : 3.24.4 -> 3.24.5
libgit2   : 1.1.0  -> 1.1.1
boost     : 1.75.0 -> 1.76.0